### PR TITLE
fix: 修复voice-library页面JavaScript错误

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -155,6 +155,15 @@ function loadFormData() {
 }
 
 document.addEventListener("DOMContentLoaded", function () {
+  // 检查是否为主页面（通过检查是否存在关键的TTS表单元素）
+  const isMainPage = document.getElementById("text") && document.getElementById("voice") && document.getElementById("speak");
+
+  // 如果不是主页面，则不执行主页面相关的初始化代码
+  if (!isMainPage) {
+    console.log("非主页面，跳过主页面初始化");
+    return;
+  }
+
   // 获取DOM元素
   const textInput = document.getElementById("text");
   const voiceSelect = document.getElementById("voice");


### PR DESCRIPTION
## 问题描述

访问 `/voice-library` 页面时出现以下 JavaScript 错误：
- `Cannot read properties of null (reading 'addEventListener')` at app.js:349:17
- `Cannot set properties of null (setting 'innerHTML')` at app.js:283:29

## 根本原因

`voice-library.html` 页面同时引入了 `app.js` 和 `voice-library.js` 两个脚本。`app.js` 中的代码期望找到主页面特有的 DOM 元素（如 `#speak`, `#voice`, `#text` 等），但在 `voice-library` 页面中，这些元素不存在。

## 修复方案

在 `app.js` 的 `DOMContentLoaded` 事件处理函数中添加页面检测逻辑：

```javascript
// 检查是否为主页面（通过检查是否存在关键的TTS表单元素）
const isMainPage = document.getElementById("text") && document.getElementById("voice") && document.getElementById("speak");

// 如果不是主页面，则不执行主页面相关的初始化代码
if (!isMainPage) {
  console.log("非主页面，跳过主页面初始化");
  return;
}
```

## 修复效果

- ✅ 消除了 `addEventListener` 相关的 TypeError
- ✅ 消除了 `innerHTML` 相关的 TypeError  
- ✅ 主页面功能保持正常
- ✅ Voice-library 页面现在可以正常加载和运行
- ✅ 保持了全局函数（如 `showCustomAlert`, `saveApiKey`）在所有页面的可用性

## 测试结果

- 主页面 (`/`) 访问正常，状态码 200
- Voice-library 页面 (`/voice-library`) 访问正常，状态码 200
- 没有出现 JavaScript 运行时错误

## 代码变更

- 文件：`web/static/js/app.js`
- 添加：9 行页面检测代码
- 无破坏性更改，向后兼容