### PR TITLE
refactor: 优化左侧边栏UI，移除统计信息并添加收藏计数

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -740,7 +740,12 @@ const Home: React.FC<HomeProps> = ({ onOpenSettings }) => {
                             {favoriteVoices.length > 0 && (
                                 <div>
                                     <div className="flex items-center justify-between mb-3">
-                                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">收藏声音</h3>
+                                        <div className="flex items-center gap-2">
+                                            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">收藏声音</h3>
+                                            <span className="inline-flex items-center justify-center w-5 h-5 text-xs font-medium text-white bg-blue-500 rounded-full">
+                                                {favoriteVoices.length}
+                                            </span>
+                                        </div>
                                         <button
                                             onClick={handleClearAllFavorites}
                                             className="text-xs text-gray-500 hover:text-red-500 transition-colors"
@@ -795,25 +800,7 @@ const Home: React.FC<HomeProps> = ({ onOpenSettings }) => {
                                 </div>
                             )}
 
-                            {/* 统计信息 */}
-                            <div>
-                                <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">统计信息</h3>
-                                <div className="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-lg p-4 space-y-3">
-                                    <div className="flex justify-between items-center">
-                                        <span className="text-sm text-gray-600">历史记录</span>
-                                        <span className="text-lg font-semibold text-gray-800">{history.length}</span>
-                                    </div>
-                                    <div className="flex justify-between items-center">
-                                        <span className="text-sm text-gray-600">收藏声音</span>
-                                        <span className="text-lg font-semibold text-gray-800">{favoriteVoices.length}</span>
-                                    </div>
-                                    <div className="flex justify-between items-center">
-                                        <span className="text-sm text-gray-600">可用声音</span>
-                                        <span className="text-lg font-semibold text-gray-800">{voices.length}</span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                          </div>
 
                       </div>
                 </aside>


### PR DESCRIPTION
## 🎯 目的
优化左侧边栏用户界面，提升用户体验

## ✅ 完成的工作

### UI改进
- **移除统计信息组件**: 删除了左侧边栏中的"统计信息"区域，包括历史记录、收藏声音、可用声音的统计卡片
- **添加收藏计数**: 在收藏声音标题中添加了蓝色圆形计数徽章，实时显示收藏数量
- **简化界面布局**: 减少了冗余信息展示，让界面更加简洁清爽

### 技术实现
- 使用现代化徽章设计 (`bg-blue-500` + `rounded-full`)
- 动态显示收藏数量 (`{favoriteVoices.length}`)
- 保持原有清空收藏功能不变

## 📊 影响范围
- **文件修改**: `frontend/src/pages/Home.tsx`
- **代码变更**: 移除18行统计信息代码，添加7行收藏计数代码
- **用户界面**: 左侧边栏更加简洁，收藏信息展示更直观

## 🧪 测试验证
- ✅ 界面加载正常
- ✅ 收藏声音计数动态更新
- ✅ 响应式布局保持正常
- ✅ 功能完整性验证通过

## 🔗 相关链接
- 实时预览: http://localhost:3000/
- 视觉改进: 现代化圆形计数徽章设计