### PR TITLE
feat: 添加API密钥到导入功能和本地构建脚本

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -250,13 +250,14 @@ const Home: React.FC<HomeProps> = ({ onOpenSettings }) => {
         try {
             setError(null);
 
-            // 构造请求参数，与TTS参数相同但不包含api_key
+            // 构造请求参数，与TTS参数相同
             const params = new URLSearchParams();
             params.append('text', text.trim());
             params.append('voice', voice);
             if (style) params.append('style', style);
             params.append('rate', rate);
             params.append('pitch', pitch);
+            params.append('api_key', localStorage.getItem('tts_api_key'));
 
             // 构造完整的请求URL
             const baseUrl = window.location.origin;
@@ -296,13 +297,14 @@ const Home: React.FC<HomeProps> = ({ onOpenSettings }) => {
         try {
             setError(null);
 
-            // 构造请求参数，与TTS参数相同但不包含api_key
+            // 构造请求参数，与TTS参数相同
             const params = new URLSearchParams();
             params.append('text', text.trim());
             params.append('voice', voice);
             if (style) params.append('style', style);
             params.append('rate', rate);
             params.append('pitch', pitch);
+            params.append('api_key', localStorage.getItem('tts_api_key'));
 
             // 构造完整的请求URL
             const baseUrl = window.location.origin;

--- a/script/build_run_local.sh
+++ b/script/build_run_local.sh
@@ -2,4 +2,4 @@
 docker build --tag zuoban/zb-tts  ..
 
 # 启动容器
-docker run --rm -p 8088:8080 zuoban/zb-tts
+docker run --rm -e TTS_API_KEY=123456 -p 8088:8080 zuoban/zb-tts


### PR DESCRIPTION
## Summary
- 为前端导入阅读和导入爱阅记功能添加api_key参数支持
- 更新本地构建脚本，添加TTS_API_KEY环境变量
- 确保导入功能可以正常调用需要认证的API端点

## Test plan
- [x] 测试导入阅读功能是否正常工作
- [x] 测试导入爱阅记功能是否正常工作
- [x] 验证本地构建脚本启动成功