### PR TITLE
fix: 将 Dockerfile 中的 npm ci 改为 npm i

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /frontend
 COPY frontend/package*.json ./
 
 # 安装前端依赖
-RUN npm ci
+RUN npm i
 
 # 复制前端源代码
 COPY frontend/ ./


### PR DESCRIPTION
## 变更说明

- **问题**: `npm ci` 在 `package-lock.json` 不匹配时会严格报错，导致 Docker 构建失败
- **修复**: 改为使用 `npm i`，提高构建灵活性
- **影响**: 降低 Docker 构建失败率，提高部署稳定性

## 测试

- 本地 Docker 构建测试通过
- 应用功能正常运行

## 风险

低风险更改，仅影响依赖安装方式，不影响应用功能