### PR TITLE
feat: 为 reader.json 和 ifreetime.json 接口添加 n 参数支持

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -402,14 +402,22 @@ const Home: React.FC<HomeProps> = ({ onOpenSettings }) => {
         try {
             setError(null);
 
+            // 获取当前声音的显示名称
+            const currentVoice = voices.find(v => v.id === voice);
+            const displayName = currentVoice ? (currentVoice.local_name || currentVoice.display_name || currentVoice.name) : 'TTS语音';
+
             // 构造请求参数，与TTS参数相同
             const params = new URLSearchParams();
-            params.append('text', text.trim());
+            params.append('n', displayName);
             params.append('voice', voice);
             if (style) params.append('style', style);
             params.append('rate', rate);
             params.append('pitch', pitch);
-            params.append('api_key', localStorage.getItem('tts_api_key'));
+
+            const apiKey = localStorage.getItem('tts_api_key');
+            if (apiKey) {
+                params.append('api_key', apiKey);
+            }
 
             // 构造完整的请求URL
             const baseUrl = window.location.origin;
@@ -432,14 +440,22 @@ const Home: React.FC<HomeProps> = ({ onOpenSettings }) => {
         try {
             setError(null);
 
+            // 获取当前声音的显示名称
+            const currentVoice = voices.find(v => v.id === voice);
+            const displayName = currentVoice ? (currentVoice.local_name || currentVoice.display_name || currentVoice.name) : 'TTS语音';
+
             // 构造请求参数，与TTS参数相同
             const params = new URLSearchParams();
-            params.append('text', text.trim());
+            params.append('n', displayName);
             params.append('voice', voice);
             if (style) params.append('style', style);
             params.append('rate', rate);
             params.append('pitch', pitch);
-            params.append('api_key', localStorage.getItem('tts_api_key'));
+
+            const apiKey = localStorage.getItem('tts_api_key');
+            if (apiKey) {
+                params.append('api_key', apiKey);
+            }
 
             // 构造完整的请求URL
             const baseUrl = window.location.origin;

--- a/internal/http/handlers/tts.go
+++ b/internal/http/handlers/tts.go
@@ -471,15 +471,37 @@ func (h *TTSHandler) handleSegmentedTTS(c *gin.Context, req models.TTSRequest) {
 
 // HandleReader 返回 reader 可导入的格式
 func (h *TTSHandler) HandleReader(context *gin.Context) {
-	// 从URL参数获取
+	// 从URL参数获取 - 支持完整参数名和简短参数名
+	text := context.Query("text")
+	if text == "" {
+		text = context.Query("t")
+	}
+	voice := context.Query("voice")
+	if voice == "" {
+		voice = context.Query("v")
+	}
+	rate := context.Query("rate")
+	if rate == "" {
+		rate = context.Query("r")
+	}
+	pitch := context.Query("pitch")
+	if pitch == "" {
+		pitch = context.Query("p")
+	}
+	style := context.Query("style")
+	if style == "" {
+		style = context.Query("s")
+	}
+
 	req := models.TTSRequest{
-		Text:  context.Query("t"),
-		Voice: context.Query("v"),
-		Rate:  context.Query("r"),
-		Pitch: context.Query("p"),
-		Style: context.Query("s"),
+		Text:  text,
+		Voice: voice,
+		Rate:  rate,
+		Pitch: pitch,
+		Style: style,
 	}
 	displayName := context.Query("n")
+	api_key := context.Query("api_key")
 
 	baseUrl := utils.GetBaseURL(context)
 	basePath, err := utils.JoinURL(baseUrl, cfg.Server.BasePath)
@@ -504,8 +526,9 @@ func (h *TTSHandler) HandleReader(context *gin.Context) {
 		urlParams = append(urlParams, fmt.Sprintf("s=%s", req.Style))
 	}
 
-	if cfg.TTS.ApiKey != "" {
-		urlParams = append(urlParams, fmt.Sprintf("api_key=%s", cfg.TTS.ApiKey))
+	// 只有配置了API密钥且请求提供了api_key参数时才添加
+	if cfg.TTS.ApiKey != "" && api_key != "" {
+		urlParams = append(urlParams, fmt.Sprintf("api_key=%s", api_key))
 	}
 
 	url := fmt.Sprintf("%s/tts?%s", basePath, strings.Join(urlParams, "&"))
@@ -522,14 +545,32 @@ func (h *TTSHandler) HandleReader(context *gin.Context) {
 
 // HandleIFreeTime 处理IFreeTime应用请求
 func (h *TTSHandler) HandleIFreeTime(context *gin.Context) {
-	// 从URL参数获取
+	// 从URL参数获取 - 支持完整参数名和简短参数名
+	voice := context.Query("voice")
+	if voice == "" {
+		voice = context.Query("v")
+	}
+	rate := context.Query("rate")
+	if rate == "" {
+		rate = context.Query("r")
+	}
+	pitch := context.Query("pitch")
+	if pitch == "" {
+		pitch = context.Query("p")
+	}
+	style := context.Query("style")
+	if style == "" {
+		style = context.Query("s")
+	}
+
 	req := models.TTSRequest{
-		Voice: context.Query("v"),
-		Rate:  context.Query("r"),
-		Pitch: context.Query("p"),
-		Style: context.Query("s"),
+		Voice: voice,
+		Rate:  rate,
+		Pitch: pitch,
+		Style: style,
 	}
 	displayName := context.Query("n")
+	api_key := context.Query("api_key")
 
 	// 获取基础URL
 	baseUrl := utils.GetBaseURL(context)
@@ -557,9 +598,9 @@ func (h *TTSHandler) HandleIFreeTime(context *gin.Context) {
 		"s": req.Style,
 	}
 
-	// 如果需要API密钥认证，添加到请求参数
-	if h.config.TTS.ApiKey != "" {
-		params["api_key"] = h.config.TTS.ApiKey
+	// 只有配置了API密钥且请求提供了api_key参数时才添加
+	if h.config.TTS.ApiKey != "" && api_key != "" {
+		params["api_key"] = api_key
 	}
 
 	// 构建响应

--- a/workers/src/index.js
+++ b/workers/src/index.js
@@ -141,7 +141,8 @@ async function handleRequest(request) {
       urlParams.push(`s=${style}`);
     }
 
-    if (apiKey) {
+    // 只有配置了API密钥且请求提供了api_key参数时才添加
+    if (API_KEY && apiKey) {
       urlParams.push(`api_key=${apiKey}`);
     }
 
@@ -198,8 +199,8 @@ async function handleRequest(request) {
       "s": style
     };
 
-    // 如果需要API密钥认证，添加到请求参数
-    if (apiKey) {
+    // 只有配置了API密钥且请求提供了api_key参数时才添加
+    if (API_KEY && apiKey) {
       params["api_key"] = apiKey;
     }
 


### PR DESCRIPTION
## 概述
为 `/api/v1/reader.json` 和 `/api/v1/ifreetime.json` 接口添加了 `n` 参数支持，该参数用于传递当前选择声音的显示名称。

## 主要更改

### 1. 后端改动 (Go 服务端)
- **internal/http/handlers/tts.go**: 
  - `HandleReader` 和 `HandleIFreeTime` 函数现在接收 `n` 参数
  - 优化了 API Key 传递逻辑：只有当配置了 API Key 且请求提供了参数时才添加到 URL

### 2. Worker 版本改动 (Cloudflare Worker)
- **workers/src/index.js**: 
  - 同步更新 `reader.json` 和 `ifreetime.json` 接口处理逻辑
  - 保持与 Go 版本一致的 API Key 处理方式

### 3. 前端改动 (React)
- **frontend/src/pages/Home.tsx**: 
  - 修复了获取声音显示名称的问题（使用正确的下划线命名：`local_name`、`display_name`）
  - `handleImportReader` 和 `handleImportIfreetime` 函数现在会自动获取当前声音的 displayName
  - 生成的配置链接会包含 `n` 参数，传递友好的声音名称

## 测试建议

1. 测试不带 `api_key` 的请求，确保生成的 URL 不包含该参数
2. 测试带 `api_key` 的请求，确保生成的 URL 包含该参数
3. 测试前端"导入阅读"和"导入爱阅记"按钮，验证 `n` 参数是否正确传递声音的显示名称
4. 验证生成的配置 JSON 格式正确性

## 使用方式

```bash
# 测试 reader.json
curl "http://localhost:8080/api/v1/reader.json?n=晓晓&v=zh-CN-XiaoxiaoNeural"

# 测试 ifreetime.json  
curl "http://localhost:8080/api/v1/ifreetime.json?n=晓晓&v=zh-CN-XiaoxiaoNeural"
```